### PR TITLE
Bugfix cannot delete without etag specifically set

### DIFF
--- a/CoreHelpers.WindowsAzure.Storage.Table/Serialization/TableEntityBuilder.cs
+++ b/CoreHelpers.WindowsAzure.Storage.Table/Serialization/TableEntityBuilder.cs
@@ -32,7 +32,7 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Serialization
                     _data.Add("RowKey", rkey.ToSha256());
                     break;
             }
-            
+
             return this;
         }
 
@@ -47,6 +47,9 @@ namespace CoreHelpers.WindowsAzure.Storage.Table.Serialization
             var entity = new TableEntity(_data);
             if (ETag != null)
                 entity.ETag = ETag;
+            else
+                entity.ETag = ETag.All;
+
             return entity;
         }
     }


### PR DESCRIPTION
This pull request makes a minor update to the `Build` method in `TableEntityBuilder.cs`. The change ensures that if `ETag` is null, it defaults to `ETag.All` instead of leaving it unset.