### PR TITLE
Include dotnet 8 in build targets

### DIFF
--- a/CoreHelpers.WindowsAzure.Storage.Table.Abstractions/CoreHelpers.WindowsAzure.Storage.Table.Abstractions.csproj
+++ b/CoreHelpers.WindowsAzure.Storage.Table.Abstractions/CoreHelpers.WindowsAzure.Storage.Table.Abstractions.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>netstandard2.0;netstandard2.1;net48</TargetFrameworks>
+        <TargetFrameworks>netstandard2.0;netstandard2.1;net48;net8.0</TargetFrameworks>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <PackageLicenseFile>LICENSE</PackageLicenseFile>
         <PackageProjectUrl>https://github.com/CoreHelpers/AzureStorageTable</PackageProjectUrl>   

--- a/CoreHelpers.WindowsAzure.Storage.Table/CoreHelpers.WindowsAzure.Storage.Table.csproj
+++ b/CoreHelpers.WindowsAzure.Storage.Table/CoreHelpers.WindowsAzure.Storage.Table.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard2.1;net48</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net48;net8.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <LangVersion>6</LangVersion>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>


### PR DESCRIPTION
This pull request updates the target frameworks for two projects to include support for `net8.0`. This change ensures compatibility with the latest .NET version while maintaining support for older frameworks.

Framework updates:

* [`CoreHelpers.WindowsAzure.Storage.Table.Abstractions/CoreHelpers.WindowsAzure.Storage.Table.Abstractions.csproj`](diffhunk://#diff-58ee32a16dfb278f8fce15190e6f98a647bf84d24b05ba7b2b23053182ddd48dL4-R4): Added `net8.0` to the `TargetFrameworks` property.
* [`CoreHelpers.WindowsAzure.Storage.Table/CoreHelpers.WindowsAzure.Storage.Table.csproj`](diffhunk://#diff-964ebb686551f50fcb45dafa8d4873332f0beb32b943c00212dfded3e802cd11L4-R4): Added `net8.0` to the `TargetFrameworks` property.